### PR TITLE
add support for optional "boost" option in a search term

### DIFF
--- a/src/main/java/com/kiblerdude/awsome/cloudsearch/StructuredQueryBuilder.java
+++ b/src/main/java/com/kiblerdude/awsome/cloudsearch/StructuredQueryBuilder.java
@@ -3,7 +3,6 @@ package com.kiblerdude.awsome.cloudsearch;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
@@ -59,6 +58,8 @@ public final class StructuredQueryBuilder {
 	private final Optional<String> value;
 	private final Optional<String> from;
 	private final Optional<String> to;
+	
+	private Optional<Integer> boost;
 
 	/**
 	 * Default constructor. Creates a <code>matchall</code> expression.
@@ -71,6 +72,7 @@ public final class StructuredQueryBuilder {
 		this.value = Optional.absent();
 		this.from = Optional.absent();
 		this.to = Optional.absent();
+		this.boost = Optional.absent();
 	}
 
 	/**
@@ -88,6 +90,7 @@ public final class StructuredQueryBuilder {
 		this.value = Optional.of(value);
 		this.from = Optional.absent();
 		this.to = Optional.absent();
+		this.boost = Optional.absent();
 	}
 
 	/**
@@ -106,6 +109,7 @@ public final class StructuredQueryBuilder {
 		this.value = Optional.absent();
 		this.from = Optional.fromNullable(from);
 		this.to = Optional.fromNullable(to);
+		this.boost = Optional.absent();
 	}
 
 	/**
@@ -123,6 +127,7 @@ public final class StructuredQueryBuilder {
 		this.value = Optional.absent();
 		this.from = Optional.absent();
 		this.to = Optional.absent();
+		this.boost = Optional.absent();
 	}
 
 	/**
@@ -139,6 +144,17 @@ public final class StructuredQueryBuilder {
 		return toString();
 	}
 
+	/**
+	 * Add a cloudsearch boost to this term.
+	 * @param boost the boost weight
+	 * @return builder pattern
+	 */
+	public StructuredQueryBuilder withBoost(int boost)
+	{
+		this.boost = Optional.of(boost);
+		return this;
+	}
+	
 	/**
 	 * Compound expressions with the <code>and</code> operator. For example:
 	 * 
@@ -414,6 +430,13 @@ public final class StructuredQueryBuilder {
 
 	@Override
 	public String toString() {
+		
+		// ensure we include the boost option if present
+		String boostStr = "";
+		if (this.boost.isPresent()) {
+			boostStr = new StringBuilder("boost=").append(boost.get()).toString();
+		}
+		
 		// there are a few conditions to check:
 		// 1. matchall queries
 		// 2. compound (nested) queries
@@ -430,11 +453,11 @@ public final class StructuredQueryBuilder {
 			return Joiner.on(' ').join(queryParts);
 		} else if (value.isPresent()) {
 			ImmutableSet<String> queryParts = ImmutableSet.of("(",
-					type.toString(), "field=", field.get(), value.get(), ")");
+					type.toString(), "field=", field.get(), boostStr, value.get(), ")");
 			return Joiner.on(' ').join(queryParts);
 		} else {
 			ImmutableSet<String> queryParts = ImmutableSet.of("(",
-					type.toString(), "field=", field.get(), "{", from.or(""),
+					type.toString(), "field=", field.get(), boostStr, "{", from.or(""),
 					",", to.or(""), "}", ")");
 			return Joiner.on(' ').join(queryParts);
 		}

--- a/src/test/java/com/kiblerdude/awsome/cloudsearch/StructureQueryBuilderTest.java
+++ b/src/test/java/com/kiblerdude/awsome/cloudsearch/StructureQueryBuilderTest.java
@@ -9,9 +9,7 @@ import static com.kiblerdude.awsome.cloudsearch.StructuredQueryBuilder.phrase;
 import static com.kiblerdude.awsome.cloudsearch.StructuredQueryBuilder.prefix;
 import static com.kiblerdude.awsome.cloudsearch.StructuredQueryBuilder.range;
 import static org.junit.Assert.assertEquals;
-
 import java.util.Date;
-
 import org.junit.Test;
 
 public class StructureQueryBuilderTest {
@@ -24,16 +22,16 @@ public class StructureQueryBuilderTest {
 	
 	@Test
 	public void testEq() {
-		Date date1 = new Date(0L);		
+		Date date1 = new Date(0L);
 		String eq1 = eq("field1", "value").toString();
 		String eq2 = eq("field1", 10L).toString();
 		String eq3 = eq("field1", 20.0).toString();
 		String eq4 = eq("field1", date1).toString();
 		
-		assertEquals("( term field= field1 'value' )", eq1.toString());
-		assertEquals("( term field= field1 10 )", eq2.toString());
-		assertEquals("( term field= field1 20.0 )", eq3.toString());
-		assertEquals("( term field= field1 '1970-01-01T00:00:00Z' )", eq4.toString());
+		assertEquals("( term field= field1  'value' )", eq1.toString());
+		assertEquals("( term field= field1  10 )", eq2.toString());
+		assertEquals("( term field= field1  20.0 )", eq3.toString());
+		assertEquals("( term field= field1  '1970-01-01T00:00:00Z' )", eq4.toString());
 	}
 	
 	@Test
@@ -45,39 +43,39 @@ public class StructureQueryBuilderTest {
 		String range3 = range("field1", 100.0, 200.0).toString();
 		String range4 = range("field1", date1, date2).toString();
 		
-		assertEquals("( range field= field1 { 'abc' , 'def' } )", range1.toString());
-		assertEquals("( range field= field1 { 10 , 20 } )", range2.toString());	
-		assertEquals("( range field= field1 { 100.0 , 200.0 } )", range3.toString());	
-		assertEquals("( range field= field1 { '1970-01-01T00:00:00Z' , '1970-01-01T00:00:01Z' } )", range4.toString());	
+		assertEquals("( range field= field1  { 'abc' , 'def' } )", range1.toString());
+		assertEquals("( range field= field1  { 10 , 20 } )", range2.toString());
+		assertEquals("( range field= field1  { 100.0 , 200.0 } )", range3.toString());
+		assertEquals("( range field= field1  { '1970-01-01T00:00:00Z' , '1970-01-01T00:00:01Z' } )", range4.toString());
 	}
 	
 	@Test
 	public void testPrefix() {
 		String prefix1 = prefix("field1", "pre").toString();
-		assertEquals("( prefix field= field1 'pre' )", prefix1.toString());
+		assertEquals("( prefix field= field1  'pre' )", prefix1.toString());
 	}
 	
 	@Test
 	public void testPhrase() {
 		String phrase1 = phrase("field1", "hello world").toString();
-		assertEquals("( phrase field= field1 'hello world' )", phrase1.toString());		
+		assertEquals("( phrase field= field1  'hello world' )", phrase1.toString());
 	}
 	
 	@Test
 	public void testCompoundAnd() {
 		String compound1 = and(eq("field1", "value1"), eq("field2", "value2")).toString();
-		assertEquals("( and ( term field= field1 'value1' ) ( term field= field2 'value2' ) )", compound1.toString());
+		assertEquals("( and ( term field= field1  'value1' ) ( term field= field2  'value2' ) )", compound1.toString());
 	}
 
 	@Test
 	public void testCompoundOr() {
 		String compound1 = or(eq("field1", "value1"), eq("field2", "value2")).toString();
-		assertEquals("( or ( term field= field1 'value1' ) ( term field= field2 'value2' ) )", compound1.toString());		
+		assertEquals("( or ( term field= field1  'value1' ) ( term field= field2  'value2' ) )", compound1.toString());
 	}
 	
 	@Test
 	public void testCompoundNot() {
 		String compound1 = and(eq("field1", "value1"), not(eq("field2", "value2"))).toString();
-		assertEquals("( and ( term field= field1 'value1' ) ( not ( term field= field2 'value2' ) ) )", compound1.toString());
+		assertEquals("( and ( term field= field1  'value1' ) ( not ( term field= field2  'value2' ) ) )", compound1.toString());
 	}
 }


### PR DESCRIPTION
Hi, we love your builder, but we could not use it without the CloudSearch "boost" feature so added this as an optional setting. It will add a query option like "boost=5" into a term. For example:
(term field=myField boost=5 'some value'). For more info, see:
http://docs.aws.amazon.com/cloudsearch/latest/developerguide/searching-compound-queries.html
